### PR TITLE
Fix GetCommitContent to actually get commit content

### DIFF
--- a/projects_commit.go
+++ b/projects_commit.go
@@ -26,11 +26,11 @@ func (s *ProjectsService) GetCommit(projectName, commitID string) (*CommitInfo, 
 	return v, resp, err
 }
 
-// GetCommitContent gets the content of a file from the HEAD revision of a certain branch.
+// GetCommitContent gets the content of a file from a certain commit.
 // The content is returned as base64 encoded string.
 //
-// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-content
-func (s *ProjectsService) GetCommitContent(projectName, branchID, fileID string) (string, *Response, error) {
-	u := fmt.Sprintf("projects/%s/branches/%s/files/%s/content", url.QueryEscape(projectName), branchID, fileID)
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html##get-content-from-commit
+func (s *ProjectsService) GetCommitContent(projectName, commitID, fileID string) (string, *Response, error) {
+	u := fmt.Sprintf("projects/%s/commits/%s/files/%s/content", url.QueryEscape(projectName), commitID, fileID)
 	return getStringResponseWithoutOptions(s.client, u)
 }


### PR DESCRIPTION
The method was accidentally duplicating GetBranchContent.